### PR TITLE
Feature-check-infeasible

### DIFF
--- a/cheval/api.py
+++ b/cheval/api.py
@@ -1,16 +1,18 @@
-from typing import Dict, Union, Set, TYPE_CHECKING, List, Generator, Hashable, Optional
 import abc
 from collections import deque
+from typing import (TYPE_CHECKING, Dict, Generator, Hashable, List, Optional,
+                    Set, Union)
 
-import pandas as pd
-import numpy as np
 import attr
+import numpy as np
+import pandas as pd
 
+from .exceptions import ModelNotReadyError
+from .ldf import LinkedDataFrame
 from .parsing.expr_items import ChainTuple
 from .parsing.expressions import Expression
-from .ldf import LinkedDataFrame
-from .exceptions import ModelNotReadyError
 from .utils import convert_series, to_numpy
+
 if TYPE_CHECKING:
     from .model import ChoiceModel
 

--- a/cheval/utils.py
+++ b/cheval/utils.py
@@ -1,7 +1,8 @@
+from typing import Union
+
+import numpy as np
 import pandas as pd
 from pandas.api.types import is_integer_dtype
-import numpy as np
-from typing import Union
 
 _USE_TO_NUMPY = hasattr(pd.Series, 'to_numpy')
 


### PR DESCRIPTION
Provide an option to use the ChoiceModel to evaluate probabilities where utility values will result in "0" probabilities when exponentiated. This would indicate that there are no feasible choices available.

This feature only applies when computing the probability distribution using `ChoiceModel.run_stochastic()`. The check cannot be disabled when using `ChoiceModel.run_discrete()` as sampling requires probabilities to equal 0.