### PR TITLE
Fix groupby for pandas >0.24

### DIFF
--- a/testing/test_ldf.py
+++ b/testing/test_ldf.py
@@ -108,3 +108,37 @@ def test_pivot_table():
     expected_result.columns.name = 'temp_0'
 
     assert_frame_equal(test_result, expected_result)
+
+
+def test_groupby():
+    """Verifies basic groupby functionality for LinkedDataFrames
+
+    Most groupby functionality should be handled by pandas, but the internal
+    implementation may differ version-to-version, which may impact the ability of
+    LinkedDataFrame objects to correctly update the linkages.
+
+    This tests that groupby can be run on LinkedDataFrames, and that the linked dataframe
+    is accessible from each group and that it contains the correct data.
+    """
+
+    df1_dict = {
+        "df2_id": [  0,   1,   2,   0,   1,   2,   0],
+        "cats":   ["F", "M", "F", "M", "F", "M", "F"],
+    }
+
+    df2_dict = {
+        "col1":   ["a", "b", "c"],
+    }
+
+    df1 = LinkedDataFrame(pd.DataFrame(df1_dict))
+    df2 = LinkedDataFrame(pd.DataFrame(df2_dict))
+
+    df1.link_to(df2, "df2", on_self="df2_id")
+
+    groups = df1.groupby("cats")
+
+    for cat, group_df in groups:
+        if cat == "F":
+            assert list(sorted(group_df.df2.col1)) == ["a", "a", "b", "c"]
+        else:
+            assert list(sorted(group_df.df2.col1)) == ["a", "b", "c"]


### PR DESCRIPTION
Fixes #4 by adding logic in `LinkedDataFrame.__finalize__` to copy over links if a newly constructed LinkedDataFrame is produced from a groupby. 

Because pandas internally moved to calling compiled code directly in a groupby, there is not even a private endpoint which can be used to intercept indexing. This meant the linkage updating had to take place in `__finalize__`, with that logic updating the linkage indexers using the indexes of the new and original LDFs.

In the process of fixing this, a bug was exposed in `LinkedDataFrame.pivot_table` using pandas 1.4. Internal to pandas, `groupby` is used within the `pivot_table` code. With LDF linkages not updating in the results of a `groupby`, the linkages from the original table were (correctly) not carried over to the result of `pivot_table`. Fixing `groupby` allowed the LDF to attempt to carry the linkages over to the `pivot_table` output, resulting in an error when it attempted to update indexers using the index of the `pivot_table`. This error was suppressed in naïve tests where the LDFs and `pivot_table` indexes are the same dimension, but was exposed when used in the GGHM Demand Model code where LDFs use MultiIndexes.

As a result, `LinkedDataFrame.pivot_table` was changed to construct a new temporary dataframe to pivot, a change which simplified the code and reduced the possibility of future `pivot_table` errors.

New tests were added for basic `groupby` functionality as well as the more complex `pivot_table` on LDFs with MultiIndexes.