### PR TITLE
Fix error when aggregating linked bool columns

### DIFF
--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -550,7 +550,7 @@ class LinkedDataFrame(DataFrame):
 
                 # A fill value of NaN is only disallowed for integer types
                 fill_value = np.nan
-                if series_type == PandasDtype.INT_NAME:
+                if series_type in {PandasDtype.INT_NAME, PandasDtype.UINT_NAME, PandasDtype.BOOL_NAME}:
                     fill_value = int_fill
                 elif series_type == PandasDtype.TIME_NAME:
                     raise NotImplementedError("Haven't found a way to instantiate NaT filler")

--- a/testing/test_ldf.py
+++ b/testing/test_ldf.py
@@ -189,3 +189,25 @@ def test_groupby():
             assert list(sorted(group_df.df2.col1)) == ["a", "a", "b", "c"]
         else:
             assert list(sorted(group_df.df2.col1)) == ["a", "b", "c"]
+
+
+def test_bool_columns():
+    """Test that bool columns get correctly handled in aggregations on linkages
+
+    Errors with bool columns originally came up when attempting to aggregate on
+    a bool expression. It is hoped that this will catch similar errors with bool
+    columns.
+    """
+
+    vehicles = LinkedDataFrame(vehicles_data)
+    households = LinkedDataFrame(households_data)
+
+    vehicles.link_to(households, 'household', on='household_id')
+    households.link_to(vehicles, 'vehicles', on='household_id')
+
+    expression = "vehicles.sum(manufacturer=='Honda')"
+    test_result = households.evaluate(expression)
+
+    expected_result = pd.Series([1, 0, 0, 1], index=households.index)
+
+    assert_series_equal(test_result, expected_result)


### PR DESCRIPTION
Closes #9 

There was existing logic to apply a compatible mask to columns with an integer datatype, so this simply adds checks for bool datatypes to that. Although they were not identified in #9, operations on columns with uint datatypes would result in the same error, so uint was also added to the check.