### PR TITLE
Fix and improve LinkedDataFrame missing link indexes logic

### DIFF
--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -94,7 +94,7 @@ class _LinkMeta:
 
     flat_indexer: Optional[np.ndarray]
     other_grouper: Optional[np.ndarray]
-    missing_indices: Optional[Union[np.ndarray, List]]
+    _missing_indices: Optional[Union[np.ndarray, List]]
 
     @staticmethod
     def create(owner: 'LinkedDataFrame', other: Union['LinkedDataFrame', DataFrame], self_labels: Union[List[str], str],
@@ -121,7 +121,7 @@ class _LinkMeta:
         self.aggregation_required = False
         self.flat_indexer = None
         self.other_grouper = None
-        self.missing_indices = None
+        self._missing_indices = None
 
     def _determine_aggregation(self, precompute):
         self_indexer = self.self_meta.get_indexer(self.owner)
@@ -163,7 +163,7 @@ class _LinkMeta:
     def _compute_missing_indices(self):
         """Initializes `missing_indices` by finding the rows which do not have any linkages
         """
-        self.missing_indices = np.nonzero(self.flat_indexer == -1)[0]
+        self._missing_indices = np.nonzero(self.flat_indexer == -1)[0]
 
     @property
     def chained(self) -> bool:
@@ -173,9 +173,9 @@ class _LinkMeta:
     def indexer_and_missing(self) -> Tuple[np.ndarray, np.ndarray]:
         if self.flat_indexer is None:
             self.precompute()
-        if self.missing_indices is None:
+        if self._missing_indices is None:
             self._compute_missing_indices()
-        return self.flat_indexer, self.missing_indices
+        return self.flat_indexer, self._missing_indices
 
     def precompute(self):
         """Top-level method to precompute the indexer"""
@@ -195,7 +195,7 @@ class _LinkMeta:
         # If we are not taking a slice, copy missing indices (if they exist)
         # If we are taking a slice, leave missing indices to be lazy-computed
         if indices is None:
-            copied.missing_indices = self.missing_indices
+            copied._missing_indices = self._missing_indices
 
         if self.other_grouper is not None:
             copied.other_grouper = self.other_grouper

--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -160,7 +160,7 @@ class _LinkMeta:
                 # (the other was missing values, or the self had NaNs).
                 # Those were combined into a single case for performance purposes
                 self.flat_indexer = other_indexer.get_indexer(self_indexer)
-                self.missing_indices = np.where(self.flat_indexer == -1)
+                self.missing_indices = np.array(np.where(self.flat_indexer == -1), dtype=int)
 
     @property
     def chained(self) -> bool:

--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -191,8 +191,10 @@ class _LinkMeta:
             copied.missing_indices = []
         elif isinstance(self.missing_indices, np.ndarray):
             if (indices is not None) and (len(self.missing_indices) > 0):
-                mask = np.isin(self.missing_indices, indices)
-                copied.missing_indices = self.missing_indices[mask]
+                # Update the indices of rows with missing linkages by finding
+                # elements of the new index which were in the original missing indices
+                new_missing_eles = np.isin(indices, self.missing_indices)
+                copied.missing_indices = np.nonzero(new_missing_eles)[0]
             else:
                 copied.missing_indices = self.missing_indices[:]
 

--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -160,7 +160,7 @@ class _LinkMeta:
                 # (the other was missing values, or the self had NaNs).
                 # Those were combined into a single case for performance purposes
                 self.flat_indexer = other_indexer.get_indexer(self_indexer)
-                self.missing_indices = np.array(np.where(self.flat_indexer == -1), dtype=int)
+                self.missing_indices = np.nonzero(self.flat_indexer == -1)[0]
 
     @property
     def chained(self) -> bool:

--- a/cheval/ldf/api.py
+++ b/cheval/ldf/api.py
@@ -155,12 +155,12 @@ class _LinkMeta:
             if self_indexer.equals(other_indexer):  # Indexers are identical
                 self.flat_indexer = np.arange(len(other_indexer))
                 self.missing_indices = np.array([], dtype=int)
-            elif len(self_indexer.difference(other_indexer)) == 0:  # No missing values
-                # Taking the difference is faster than `all(.isin())`
-                self.missing_indices = np.array([], dtype=int)
+            else:
+                # Originally, different logic was used if the self indexer didn't map cleanly onto the other indexer
+                # (the other was missing values, or the self had NaNs).
+                # Those were combined into a single case for performance purposes
                 self.flat_indexer = other_indexer.get_indexer(self_indexer)
-            else:  # All other cases
-                self.flat_indexer, self.missing_indices = other_indexer.get_indexer_non_unique(self_indexer)
+                self.missing_indices = np.where(self.flat_indexer == -1)
 
     @property
     def chained(self) -> bool:


### PR DESCRIPTION
Closes #11 and closes #13 - two separate problems related to how LinkedDataFrames handle linkages where some rows don't have matches in the linked dataframe.

#11 was happening due to the use of `pandas.Index.get_indexer_non_unique` to compute both the indexer and missing values. An apparent performance regression in pandas 1.4 meant that `get_indexer_non_unique` had a quadratic runtime for indexes with missing values when using MultiIndexes.

#13 was happening due to an error in the way Cheval attempted to update the missing indices when a dataframe was sliced. This was not observed in previous usage of Cheval in the GGHMv4, as Cheval would not handle missing indices correctly if those indices originated from `NaN` values.

This fix addresses both problems by totally removing pre-computation of the missing indices. Instead, link indexes are computed using `pandas.Index.get_indexer`, and missing indices are computed for each slice whenever they are first needed.

Performance impacts were profiled via sample runs of the GGHMv4 using pandas 1.4.2 and pandas 0.24.2. Runs using the fix produced identical output to runs using Cheval v0.2.2. The fix reduced model runtime by ~25% in both versions of pandas, so there does not appear to be any risk of performance regressions due to this change. In standalone tests, re-computing and caching the missing indices for slices was faster than updating from an existing missing index array, and the lazy evaluation may also eliminate computation of missing indices which are never actually used.

Also adds a new test for #13 and other missing link index behaviour.